### PR TITLE
bugfix/clean-folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+Rubbish/
 MANIFEST
 
 # PyInstaller

--- a/main.py
+++ b/main.py
@@ -1,14 +1,30 @@
-import sys
 from pathlib import Path
 import sort
 
 if __name__ =="__main__":
     
-    folder_to_scan = sys.argv[1]
-              
-    sort.read_folder(Path(folder_to_scan), Path(folder_to_scan))
+    while True:
+        folder_to_scan = input('Please, enter the path of folder should be cleaned: ')
+        if not Path(folder_to_scan).is_dir():
+            print('The entered path is not a folder. Try again.')
+        else:
+            break
+
+    while True:
+        destination_folder = input('Please, enter the path of destination folder: ')
+        if not Path(destination_folder).is_dir():
+            _ = input('The entered folder does not exist. Do you want create new folder? (y/n): ')
+            if _ == 'y':
+                Path(destination_folder).mkdir(mode=511, exist_ok=True, parents=True)
+                break
+        else:
+            break
+        
+            
+    sort.read_folder(Path(folder_to_scan), Path(destination_folder))
 
     sort.handle_empty_folders(Path(folder_to_scan)) 
-
+    
+    exit()
     
 

--- a/main.py
+++ b/main.py
@@ -1,30 +1,31 @@
 from pathlib import Path
 import sort
 
-if __name__ =="__main__":
+def main():
+    if __name__ =="__main__()":
     
-    while True:
-        folder_to_scan = input('Please, enter the path of folder should be cleaned: ')
-        if not Path(folder_to_scan).is_dir():
-            print('The entered path is not a folder. Try again.')
-        else:
-            break
-
-    while True:
-        destination_folder = input('Please, enter the path of destination folder: ')
-        if not Path(destination_folder).is_dir():
-            _ = input('The entered folder does not exist. Do you want create new folder? (y/n): ')
-            if _ == 'y':
-                Path(destination_folder).mkdir(mode=511, exist_ok=True, parents=True)
+        while True:
+            folder_to_scan = input('Please, enter the path of folder should be cleaned: ')
+            if not Path(folder_to_scan).is_dir():
+                print('The entered path is not a folder. Try again.')
+            else:
                 break
-        else:
-            break
+
+        while True:
+            destination_folder = input('Please, enter the path of destination folder: ')
+            if not Path(destination_folder).is_dir():
+                _ = input('The entered folder does not exist. Do you want create new folder? (y/n): ')
+                if _ == 'y':
+                    Path(destination_folder).mkdir(mode=511, exist_ok=True, parents=True)
+                    break
+            else:
+                break
         
             
-    sort.read_folder(Path(folder_to_scan), Path(destination_folder))
+        sort.read_folder(Path(folder_to_scan), Path(destination_folder))
 
-    sort.handle_empty_folders(Path(folder_to_scan)) 
+        sort.handle_empty_folders(Path(folder_to_scan)) 
     
-    exit()
+        exit()
     
 

--- a/main.py
+++ b/main.py
@@ -1,38 +1,14 @@
-'''
-Завдання: Сортування файлів у папці.
-
-Перенести файли із зазначеної папки в нову папку з розширенням цього файлу:
-зображення переносимо до папки images
-документи переносимо до папки documents
-аудіо файли переносимо в audio
-відео файли у video
-архіви розпаковуються та їх вміст переноситься до папки archives
-'''
 import sys
 from pathlib import Path
-import shutil
-import re
 import sort
-
-# python main.py <Name of folder> 
 
 if __name__ =="__main__":
     
     folder_to_scan = sys.argv[1]
               
-    sort.read_folder(Path(folder_to_scan), Path(folder_to_scan)) # Обробляємо папку
+    sort.read_folder(Path(folder_to_scan), Path(folder_to_scan))
 
-    sort.handle_empty_folders(Path(folder_to_scan)) # після сортування файлів у папці видаляємо пусті папки, що утворилися після упорядкування, і нормалізуємо назви файлів
+    sort.handle_empty_folders(Path(folder_to_scan)) 
 
-    # Друкуємо список файлів у категорії (музика, відео, фото та ін.)
-    print(f'Images: {sort.images}') 
-    print(f'Video: {sort.video}')
-    print(f'Documents: {sort.documents}')
-    print(f'Audio: {sort.audio}')
-    print(f'Archives: {sort.archives}')
-    print(f'Other files: {sort.my_others}')
-    # Друкуєхмо перелік всіх відомих скриптів розширень, які зустрічаються в цільовій папці.
-    print(f'Types of files in folder: {sort.EXTENSION}')
-    # Друкуємо перелік усіх розширень, які скрипту невідомі.
-    print(f'Files of Unknown types: {sort.unknown}')
+    
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+'''
+Завдання: Сортування файлів у папці.
+
+Перенести файли із зазначеної папки в нову папку з розширенням цього файлу:
+зображення переносимо до папки images
+документи переносимо до папки documents
+аудіо файли переносимо в audio
+відео файли у video
+архіви розпаковуються та їх вміст переноситься до папки archives
+'''
+import sys
+from pathlib import Path
+import shutil
+import re
+import sort
+
+# python main.py <Name of folder> 
+
+if __name__ =="__main__":
+    
+    folder_to_scan = sys.argv[1]
+              
+    sort.read_folder(Path(folder_to_scan), Path(folder_to_scan)) # Обробляємо папку
+
+    sort.handle_empty_folders(Path(folder_to_scan)) # після сортування файлів у папці видаляємо пусті папки, що утворилися після упорядкування, і нормалізуємо назви файлів
+
+    # Друкуємо список файлів у категорії (музика, відео, фото та ін.)
+    print(f'Images: {sort.images}') 
+    print(f'Video: {sort.video}')
+    print(f'Documents: {sort.documents}')
+    print(f'Audio: {sort.audio}')
+    print(f'Archives: {sort.archives}')
+    print(f'Other files: {sort.my_others}')
+    # Друкуєхмо перелік всіх відомих скриптів розширень, які зустрічаються в цільовій папці.
+    print(f'Types of files in folder: {sort.EXTENSION}')
+    # Друкуємо перелік усіх розширень, які скрипту невідомі.
+    print(f'Files of Unknown types: {sort.unknown}')
+

--- a/sort.py
+++ b/sort.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 import shutil
 import re
-import os
+
 
 images = []
 documents = []
@@ -63,11 +63,7 @@ DYRECTORY_NAME = {
 EXTENSION = set()
 
 def read_folder(path: Path, folder_to_scan: Path) -> None:
-    """
-    Функція виконує ітераційне зчитування заданої папки (path), відправляючи на обробку файли з цієї і вкладених папок.
-
-    Параметри path і folder_for_scan обов'язкові, передбачають тип даних Path.
-    """
+    
     for el in path.iterdir():
         if Path(el).is_dir():
             if el.name not in ('Archives', 'Video', 'Audio', 'Documents', 'Images', 'My others'):
@@ -77,11 +73,7 @@ def read_folder(path: Path, folder_to_scan: Path) -> None:
             handle_file(fullname, path, folder_to_scan)
 
 def handle_file(file: Path, path: Path, folder_to_scan: Path) -> None:
-    """
-    Функція опрацьовує заданий файл (file) (приведення його назви у нормалізований вигляд і підбір відповідної папки для його переміщення).
-
-    Параметри file. path і folder_to_scan обов'язкові, передбачають тип даних Path.
-    """
+    
     file_name = file.name.split('.')[0]
     ext = file.suffix[1:]
          
@@ -105,11 +97,7 @@ def handle_file(file: Path, path: Path, folder_to_scan: Path) -> None:
             handle_folder(file, folder_to_scan, target_directory)
 
 def normalize(element: str) -> str:
-    """
-    Функція здійснює в рядку elementтранслітерацію кирилиці на латинський алфавіт, а також Замінює всі символи, окрім латинських літер, цифр на '_'.
-
-    Параметр element обов'язковий, передбачає тип даних String.
-    """
+    
     CYRILLIC_SYMBOLS = "абвгдеёжзийклмнопрстуфхцчшщъыьэюяєіїґ"
     TRANSLATION = ("a", "b", "v", "g", "d", "e", "e", "j", "z", "i", "j", "k", "l", "m", "n", "o", "p", "r", "s", "t", "u",
                "f", "h", "ts", "ch", "sh", "sch", "", "y", "", "e", "yu", "ya", "je", "i", "ji", "g")
@@ -122,11 +110,7 @@ def normalize(element: str) -> str:
     return element_trans
 
 def handle_folder(file: Path, folder_to_scan: Path, target_folder: Path) -> None:
-    """
-    Функція створює задану папку (target_folder) і переносить в неї заданий файл (file).
-
-    Параметрм file, folder_to_scan і target_folder - обов'язкові, передбачають тип даних Path.
-    """
+    
     target_folder.mkdir(exist_ok=True, parents=True)
     if target_folder == folder_to_scan / 'Archives':
         handle_archive(file, target_folder)
@@ -134,11 +118,7 @@ def handle_folder(file: Path, folder_to_scan: Path, target_folder: Path) -> None
         file.replace(target_folder / normalize(file.name))
    
 def handle_archive(file: Path, target_folder: Path) -> None:
-    """
-    Функція створює папку і розпаковує в неї архів (file).
-
-    Параметри file і target_folder обов'язкові, передбачають тип даних Path.
-    """
+    
     archive_name = normalize(file.name.replace(file.suffix,''))
     folder_for_file = target_folder / archive_name
     folder_for_file.mkdir(exist_ok=True, parents=True)
@@ -153,11 +133,7 @@ def handle_archive(file: Path, target_folder: Path) -> None:
     file.unlink()
 
 def handle_empty_folders(path: Path) -> None:
-    """
-    Функція видаляє пусті папки із заданої директорії (path).
     
-    Параметр path обов'язковий, передбачає тип даних Path.
-    """
     for el in path.iterdir():
          if el.is_dir() and el.name not in ('Archives', 'Video', 'Audio', 'Documents', 'Images', 'My others'):
             try:
@@ -166,11 +142,7 @@ def handle_empty_folders(path: Path) -> None:
                 print('The folder is not emty')
                 
 def rename_files_and_folders(path: Path) -> None:
-    """
-    Функція нормалізує назви усіх папок і файлів у заданій папці (path).
     
-    Параметр path обов'язковий, передбачає тип даних Path.
-    """
     for el in path.iterdir():
         if el.is_dir():
             path = el.replace(path / normalize(el.name))

--- a/sort.py
+++ b/sort.py
@@ -1,0 +1,181 @@
+import sys
+from pathlib import Path
+import shutil
+import re
+import os
+
+images = []
+documents = []
+audio = []
+video = []
+archives = []
+unknown = []
+my_others = []
+REGISTER_EXTENSION = {
+    'JPEG': images,
+    'JPG': images,
+    'PNG': images,
+    'SVG': images,
+    'AVI': video, 
+    'MP4': video, 
+    'MOV': video, 
+    'MKV': video,
+    'DOC': documents, 
+    'DOCX': documents,
+    'TXT': documents, 
+    'PDF': documents, 
+    'XLSX': documents, 
+    'PPTX': documents,
+    'MP3': audio,
+    'OGG': audio, 
+    'WAV': audio, 
+    'AMR': audio,
+    'M4A': audio,
+    'ZIP': archives,
+    'GZ': archives, 
+    'TAR': archives
+}
+
+DYRECTORY_NAME = {
+    'JPEG': "Images",
+    'JPG': "Images",
+    'PNG': "Images",
+    'SVG': "Images",
+    'AVI': "Video", 
+    'MP4': "Video", 
+    'MOV': "Video", 
+    'MKV': "Video",
+    'DOC': "Documents", 
+    'DOCX': "Documents",
+    'TXT': "Documents", 
+    'PDF': "Documents", 
+    'XLSX': "Documents", 
+    'PPTX': "Documents",
+    'MP3': "Audio",
+    'OGG': "Audio", 
+    'WAV': "Audio", 
+    'AMR': "Audio",
+    'M4A': "Audio",
+    'ZIP': "Archives",
+    'GZ': "Archives", 
+    'TAR': "Archives"
+}
+EXTENSION = set()
+
+def read_folder(path: Path, folder_to_scan: Path) -> None:
+    """
+    Функція виконує ітераційне зчитування заданої папки (path), відправляючи на обробку файли з цієї і вкладених папок.
+
+    Параметри path і folder_for_scan обов'язкові, передбачають тип даних Path.
+    """
+    for el in path.iterdir():
+        if Path(el).is_dir():
+            if el.name not in ('Archives', 'Video', 'Audio', 'Documents', 'Images', 'My others'):
+                read_folder(Path(el), folder_to_scan)
+        else:
+            fullname = path / el.name
+            handle_file(fullname, path, folder_to_scan)
+
+def handle_file(file: Path, path: Path, folder_to_scan: Path) -> None:
+    """
+    Функція опрацьовує заданий файл (file) (приведення його назви у нормалізований вигляд і підбір відповідної папки для його переміщення).
+
+    Параметри file. path і folder_to_scan обов'язкові, передбачають тип даних Path.
+    """
+    file_name = file.name.split('.')[0]
+    ext = file.suffix[1:]
+         
+    if not ext:  
+        my_others.append(normalize(file.name))
+        target_directory = folder_to_scan / 'My others'
+        handle_folder(file, folder_to_scan, target_directory)
+    else:
+        name = file_name+ '.' + ext
+        file = path / name
+        try:
+            container = REGISTER_EXTENSION[ext.upper()]
+            EXTENSION.add(ext.upper())
+            container.append(normalize(file.name))
+            target_directory = folder_to_scan / DYRECTORY_NAME[ext.upper()]
+            handle_folder(file, folder_to_scan, target_directory)
+        except KeyError:
+            unknown.append(ext)
+            my_others.append(normalize(file.name))
+            target_directory = folder_to_scan / 'My others'
+            handle_folder(file, folder_to_scan, target_directory)
+
+def normalize(element: str) -> str:
+    """
+    Функція здійснює в рядку elementтранслітерацію кирилиці на латинський алфавіт, а також Замінює всі символи, окрім латинських літер, цифр на '_'.
+
+    Параметр element обов'язковий, передбачає тип даних String.
+    """
+    CYRILLIC_SYMBOLS = "абвгдеёжзийклмнопрстуфхцчшщъыьэюяєіїґ"
+    TRANSLATION = ("a", "b", "v", "g", "d", "e", "e", "j", "z", "i", "j", "k", "l", "m", "n", "o", "p", "r", "s", "t", "u",
+               "f", "h", "ts", "ch", "sh", "sch", "", "y", "", "e", "yu", "ya", "je", "i", "ji", "g")
+    TRANS = {}
+    for c, l in zip(CYRILLIC_SYMBOLS, TRANSLATION):
+        TRANS[ord(c)] = l
+        TRANS[ord(c.upper())] = l.upper()
+    element_trans = element.translate(TRANS)
+    element_trans = re.sub(r'\W^\.', '_', element_trans)    
+    return element_trans
+
+def handle_folder(file: Path, folder_to_scan: Path, target_folder: Path) -> None:
+    """
+    Функція створює задану папку (target_folder) і переносить в неї заданий файл (file).
+
+    Параметрм file, folder_to_scan і target_folder - обов'язкові, передбачають тип даних Path.
+    """
+    target_folder.mkdir(exist_ok=True, parents=True)
+    if target_folder == folder_to_scan / 'Archives':
+        handle_archive(file, target_folder)
+    else:
+        file.replace(target_folder / normalize(file.name))
+   
+def handle_archive(file: Path, target_folder: Path) -> None:
+    """
+    Функція створює папку і розпаковує в неї архів (file).
+
+    Параметри file і target_folder обов'язкові, передбачають тип даних Path.
+    """
+    archive_name = normalize(file.name.replace(file.suffix,''))
+    folder_for_file = target_folder / archive_name
+    folder_for_file.mkdir(exist_ok=True, parents=True)
+    # archives.append(normalize(file.name))
+    try:
+        shutil.unpack_archive(file, folder_for_file)
+        rename_files_and_folders(folder_for_file)
+    except shutil.ReadError:
+        print('It is not archive')
+        folder_for_file.rmdir()
+    print(f'archive = {file}')
+    file.unlink()
+
+def handle_empty_folders(path: Path) -> None:
+    """
+    Функція видаляє пусті папки із заданої директорії (path).
+    
+    Параметр path обов'язковий, передбачає тип даних Path.
+    """
+    for el in path.iterdir():
+         if el.is_dir() and el.name not in ('Archives', 'Video', 'Audio', 'Documents', 'Images', 'My others'):
+            try:
+                el.rmdir()
+            except:
+                print('The folder is not emty')
+                
+def rename_files_and_folders(path: Path) -> None:
+    """
+    Функція нормалізує назви усіх папок і файлів у заданій папці (path).
+    
+    Параметр path обов'язковий, передбачає тип даних Path.
+    """
+    for el in path.iterdir():
+        if el.is_dir():
+            path = el.replace(path / normalize(el.name))
+            rename_files_and_folders(path)
+        else:
+            el.replace(path / normalize(el.name))
+
+                    

--- a/sort.py
+++ b/sort.py
@@ -45,16 +45,16 @@ def handle_file(file: Path, path: Path, destination_folder: Path) -> None:
          
     if not ext:  
         target_folder = destination_folder / 'Others'
-        replace_file(file, target_folder)
+        transfer_file(file, target_folder)
     else:
         name = file_name + '.' + ext
         file = path / name
         try:
             target_folder = destination_folder / DIRECTORY_NAME[ext.upper()]
-            replace_file(file, target_folder)
+            transfer_file(file, target_folder)
         except KeyError:
             target_folder = destination_folder / 'Others'
-            replace_file(file, target_folder)
+            transfer_file(file, target_folder)
 
 def normalize(element: str) -> str:
     
@@ -69,7 +69,7 @@ def normalize(element: str) -> str:
     element_trans = re.sub(r'\W^\.', '_', element_trans)    
     return element_trans
 
-def replace_file(file: Path, target_folder: Path) -> None:
+def transfer_file(file: Path, target_folder: Path) -> None:
     target_folder.mkdir(exist_ok=True, parents=True)
     ext = file.suffix[1:].upper()
     if ext in DIRECTORY_NAME and DIRECTORY_NAME[ext] == 'Archives':


### PR DESCRIPTION
'Clean folder' asks user about folder should be cleaned and destination folder for sorted files. 
Files are sorted in accordance with their extensions. If the extension is unknown or empty files are transferred in folder with name 'Others'. 
The names of files should be normalized. The archives should be unpacked in the folder with name equal the name of archive in the folder 'Archives'. 
After running of application the initial folder should be empty.
